### PR TITLE
Prevent bots from being sacrificed

### DIFF
--- a/commands/community/sacrifice.js
+++ b/commands/community/sacrifice.js
@@ -45,7 +45,13 @@ export default class SacrificeCommand extends CoopCommand {
 				const sacrificeText = `**<@${msg.author.id}> used their instant sacrifice power to offer <@${target.id}> for ${CHANNELS.textRef('SACRIFICE')}.`;
 				return MESSAGES.silentSelfDestruct(msg, sacrificeText, 0, 60000);
 			}
-			
+
+			// Prevent bots from being proposed as a sacrifice from someone without instant sacrifice power
+			if (target.bot) {
+				const invalidText = 'You cannot propose a bot as a sacrifice.';
+				return MESSAGES.silentSelfDestruct(msg, invalidText);
+			}
+
 			// Output a consent awaiting message attempting to unban the user
 			const sacrificeText = `**Vote on offering <@${target.id}> for ${CHANNELS.textRef('SACRIFICE')}:**\n\n` +
 				`_Press ${DAGGER} to vote to offer :dagger:._`;

--- a/operations/members/redemption/prospectHelper.js
+++ b/operations/members/redemption/prospectHelper.js
@@ -22,8 +22,8 @@ export default class ProspectHelper {
                 };
             });
 
-            // Select only the ready ones.
-            const readyProspects = Array.from(prospectCandidates.filter(p => p.ready));
+            // Select only the ready and non-bot prospects.
+            const readyProspects = Array.from(prospectCandidates.filter(p => p.ready && !p.bot));
             if (readyProspects.length === 0)
                 // Offer subliminal hint that there are no prospects ready at all.
                 return CHANNELS._tempSend('TALK', 'Recruit?', 333, 4444);

--- a/operations/members/redemption/sacrificeHelper.js
+++ b/operations/members/redemption/sacrificeHelper.js
@@ -146,6 +146,10 @@ export default class SacrificeHelper {
 
 
     static async processBackDagger(reaction) {
+        author = reaction.message.author
+        // Return if the message being reacted to was from a bot.
+        if (author.bot) return;
+
         const guild = COOP.SERVER.getByCode(COOP.STATE.CLIENT, 'PROD');
 
         // Calculate the number of required votes for the redemption poll.
@@ -162,7 +166,7 @@ export default class SacrificeHelper {
 
         // Limit this to only reaction to a certain count of emojis, fire once.
         if (sacrificeVotes === reqSacrificeVotes) {
-            const targetID = reaction.message.author.id;
+            const targetID = author.id;
             const targetMember = await COOP.USERS.fetchMemberByID(guild, targetID);
 
             // TODO: Award points to backstabbers
@@ -294,6 +298,8 @@ export default class SacrificeHelper {
         try {
             // Select a member at random.
             const member = await COOP.USERS.random();
+            // If the member is a bot, select another member.
+            if (member.bot) return await this.random()
 
             // Access the sacrifice channel for sacrifice data.
             

--- a/operations/members/redemption/sacrificeHelper.js
+++ b/operations/members/redemption/sacrificeHelper.js
@@ -299,7 +299,7 @@ export default class SacrificeHelper {
             // Select a member at random.
             const member = await COOP.USERS.random();
             // If the member is a bot, select another member.
-            if (member.bot) return await this.random()
+            if (member.bot) return await this.random();
 
             // Access the sacrifice channel for sacrifice data.
             

--- a/operations/members/redemption/sacrificeHelper.js
+++ b/operations/members/redemption/sacrificeHelper.js
@@ -146,10 +146,6 @@ export default class SacrificeHelper {
 
 
     static async processBackDagger(reaction) {
-        author = reaction.message.author
-        // Return if the message being reacted to was from a bot.
-        if (author.bot) return;
-
         const guild = COOP.SERVER.getByCode(COOP.STATE.CLIENT, 'PROD');
 
         // Calculate the number of required votes for the redemption poll.
@@ -166,7 +162,7 @@ export default class SacrificeHelper {
 
         // Limit this to only reaction to a certain count of emojis, fire once.
         if (sacrificeVotes === reqSacrificeVotes) {
-            const targetID = author.id;
+            const targetID = reaction.message.author.id;
             const targetMember = await COOP.USERS.fetchMemberByID(guild, targetID);
 
             // TODO: Award points to backstabbers


### PR DESCRIPTION
This PR prevents bots from being sacrificed by users through the `!sacrifice` command, a dagger reaction or automatically (`SacrificeHelper.random`). Commanders/leaders can still sacrifice bots through the dagger reaction.

Note: this PR is untested.